### PR TITLE
Update with upstream to allow commentbox.io comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed very long strings to wrap around the next line rather than go off-screen (#787)
 - Added `footer-hover-col` config setting to customize the hover colour of links in the footer (#848)
 - Added social network link for Discord (#907)
+- Added CommentBox as comment option (#960)
 
 ## v5.0.0 (2020-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,11 @@
 - Updated staticman from using v2 (public servers) to v3 (private servers) due to the public servers becoming obsolete (#775)
 - Added support for Cloudflare Analytics (#797)
 - Added Reddit in share options of posts (#815)
-- Added support for giscus comments (#886)
+- Added support for giscus comments (#886) and CommentBox (#960)
 - Fixed bug where staticman didn't work jQuery slim version is used (#766)
 - Fixed very long strings to wrap around the next line rather than go off-screen (#787)
 - Added `footer-hover-col` config setting to customize the hover colour of links in the footer (#848)
-- Added social network link for Discord (#907)
-- Added CommentBox as comment option (#960)
+- Added social network links for Discord (#907) and Kaggle (#961)
 
 ## v5.0.0 (2020-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed bug where staticman didn't work jQuery slim version is used (#766)
 - Fixed very long strings to wrap around the next line rather than go off-screen (#787)
 - Added `footer-hover-col` config setting to customize the hover colour of links in the footer (#848)
-- Added social network links for Discord (#907) and Kaggle (#961)
+- Added social network links for Discord (#907), Kaggle (#961), and Hackerrank (#978)
 
 ## v5.0.0 (2020-09-15)
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ subtitle    | Short description of page or blog post that goes under the title
 tags        | List of tags to categorize the post. Separate the tags with commas and place them inside square brackets. Example: `[personal, analysis, finance]`
 cover-img   | Include a large full-width image at the top of the page. You can either provide the path to a single image (eg. `"/path/to/img"`) , or a list of images to cycle through (eg. `["/path/img1", "/path/img2"]`). If you want to add a caption to an image, then you must use the list notation (use `[]` even if you have only one image), and each image should be provided as `"/path/to/img" : "Caption of image"`.
 thumbnail-img | For blog posts, if you want to add a thumbnail that will show up in the feed, use `thumbnail-img: /path/to/image`. If no thumbnail is provided, then `cover-img` will be used as the thumbnail. You can use `thumbnail-img: ""` to disable a thumbnail.
-comments    | If you want do add comments to a specific page, use `comments: true`. Comments only work if you enable one of the comments providers (Facebook, disqus, staticman, utterances, giscus) in `_config.yml` file. Comments are automatically enabled on blog posts but not on other pages; to turn comments off for a specific post, use `comments: false`.
+comments    | If you want do add comments to a specific page, use `comments: true`. Comments only work if you enable one of the comments providers (Facebook, disqus, staticman, utterances, giscus, CommentBox) in `_config.yml` file. Comments are automatically enabled on blog posts but not on other pages; to turn comments off for a specific post, use `comments: false`.
 
 ## Parameters for SEO and social media sharing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ __Check out [*What's New?*](https://beautifuljekyll.com/updates/) to see the lat
 - **Flexible usage**: Use Beautiful Jekyll directly on GitHub or via a Ruby gem - choose the best [development method](#build-your-website-in-3-steps) for you.
 - **Battle-tested**: By using Beautiful Jekyll, you'll be joining 50,000+ users enjoying this theme since 2015.
 - **SEO and social media support**: Customize how your site looks on Google and when shared on social media.
-- **Comments support**: Add comments to any page using either [Disqus](https://disqus.com/), [Facebook comments](https://developers.facebook.com/docs/plugins/comments), [Utterances](https://utteranc.es/), [Staticman](https://staticman.net), or [giscus](https://giscus.app).
+- **Comments support**: Add comments to any page using either [Disqus](https://disqus.com/), [Facebook comments](https://developers.facebook.com/docs/plugins/comments), [Utterances](https://utteranc.es/), [Staticman](https://staticman.net), [giscus](https://giscus.app), or [CommentBox](https://commentbox.io/).
 - **Tags**: Any blog post can be tagged with keywords, and an index page is automatically generated.
 - **Analytics**: Easily integrate Google Analytics, or other analytics platforms, to track visits to your website.
 - **Search**: Let users easily find any page using a Search button in the navigation bar.

--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,7 @@ social-network-links:
 #  ORCID: your ORCID ID
 #  google-scholar: your google scholar
 #  discord: invite/invite_code or users/userid 
+#  kaggle: yourname
 
 # If you want your website to generate an RSS feed, provide a description
 # The URL for the feed will be https://<your_website>/feed.xml

--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,7 @@ social-network-links:
 #  google-scholar: your google scholar
 #  discord: invite/invite_code or users/userid 
 #  kaggle: yourname
+#  hackerrank: yourname
 
 # If you want your website to generate an RSS feed, provide a description
 # The URL for the feed will be https://<your_website>/feed.xml

--- a/_config.yml
+++ b/_config.yml
@@ -161,6 +161,9 @@ footer-hover-col: "#0085A1"
 # To use Facebook Comments, create a Facebook app and fill in the Facebook App ID
 #fb_comment_id: ""
 
+# To use CommentBox, sign up for a Project ID on https://commentbox.io
+#commentbox: "" # Project ID, e.g. "5694267682979840-proj"
+
 # To use Utterances comments: (0) uncomment the following section, (1) fill in
 # "repository" (make sure the repository is public), (2) Enable Issues in your repository,
 # (3) Install the Utterances app in your repository https://github.com/apps/utterances

--- a/_includes/commentbox.html
+++ b/_includes/commentbox.html
@@ -1,0 +1,7 @@
+{% if site.commentbox %}
+
+    <div class="commentbox"></div>
+    <script src="https://unpkg.com/commentbox.io/dist/commentBox.min.js"></script>
+    <script>commentBox('{{ site.commentbox }}')</script>
+
+{% endif %}

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -4,4 +4,5 @@
   {% include staticman-comments.html %}
   {% include utterances-comment.html %}
   {% include giscus-comment.html %}
+  {% include commentbox.html %}
 {% endif %}

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -324,4 +324,16 @@
   </li>
 {%- endif -%}
 
+{%- if site.social-network-links.hackerrank -%}
+  <li class="list-inline-item">
+    <a href="https://www.hackerrank.com/{{ site.social-network-links.hackerrank }}" title="Hackerrank">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-hackerrank fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Hackerrank</span>
+   </a>
+  </li>
+{%- endif -%}
+
 </ul>

--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -311,5 +311,17 @@
    </a>
   </li>
 {%- endif -%}
+  
+{%- if site.social-network-links.kaggle -%}
+  <li class="list-inline-item">
+    <a href="https://www.kaggle.com/{{ site.social-network-links.kaggle }}" title="Kaggle">
+      <span class="fa-stack fa-lg" aria-hidden="true">
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-kaggle fa-stack-1x fa-inverse"></i>
+      </span>
+      <span class="sr-only">Kaggle</span>
+   </a>
+  </li>
+{%- endif -%}
 
 </ul>


### PR DESCRIPTION
Update local copy with upstream so that we can use commentbox.io comments vs Disqus which personally I was only using cause I couldn't find a better option at the time.